### PR TITLE
add support to use S3 compatible storage servers

### DIFF
--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -1,0 +1,61 @@
+# Copy this file to another location and modify as necessary.
+version: "3"
+services:
+  minio:
+    image: minio/minio:latest
+    ports:
+      - "9000:9000"
+    volumes:
+      - miniodata:/data
+    environment:
+      # force using given key-secret instead of creating at start
+      - MINIO_ACCESS_KEY=${AWS_ACCESS_KEY_ID}
+      - MINIO_SECRET_KEY=${AWS_SECRET_ACCESS_KEY}
+    command: ["server", "/data"]
+  app:
+    image: jasonwhite0/rudolfs:latest
+    #    build:
+    #      context: .
+    #      dockerfile: Dockerfile
+    ports:
+      - "8081:8080"
+    volumes:
+      - data:/data
+    restart: always
+    environment:
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+      - LFS_ENCRYPTION_KEY=${LFS_ENCRYPTION_KEY}
+      - LFS_S3_BUCKET=${LFS_S3_BUCKET}
+      - LFS_MAX_CACHE_SIZE=${LFS_MAX_CACHE_SIZE}
+      - AWS_S3_ENDPOINT=http://minio:9000
+    entrypoint:
+      - /tini
+      - --
+      - /rudolfs
+      - --cache-dir
+      - /data
+      - --key
+      - ${LFS_ENCRYPTION_KEY}
+      - --s3-bucket
+      - ${LFS_S3_BUCKET}
+      - --max-cache-size
+      - ${LFS_MAX_CACHE_SIZE}
+    links:
+      - minio
+  # A real production server should use nginx. How to configure this depends on
+  # your needs. Use your Google-search skills to configure this correctly.
+  #
+  # nginx:
+  #   image: nginx:stable
+  #   ports:
+  #     - 80:80
+  #     - 443:443
+  #   volumes:
+  #     - ./nginx.conf:/etc/nginx/nginx.conf
+  #     - ./nginx/errors.log:/etc/nginx/errors.log
+
+volumes:
+  data:
+  miniodata:

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -95,10 +95,16 @@ impl Backend {
         while prefix.ends_with('/') {
             prefix.pop();
         }
-
         // `Region::default` will get try to get the region from the environment
         // and fallback to a default if it isn't found.
-        Backend::with_client(S3Client::new(Region::default()), bucket, prefix)
+        let mut region = Region::default();
+        if let Ok(endpoint) = std::env::var("AWS_S3_ENDPOINT") {
+            region = Region::Custom {
+                name: region.name().to_owned(),
+                endpoint: endpoint,
+            }
+        }
+        Backend::with_client(S3Client::new(region), bucket, prefix)
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to use minio and ceph as S3 backend by reading `AWS_S3_ENDPOINT` environment variable. Also, I created the `docker-compose.minio.yml` file to show how to use minio. But it requires to create bucket manually.