### PR TITLE
Use S3 signed URL for upload & allows specifying download domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /test.sh
 /cache/
 .env
+/.idea

--- a/src/app.rs
+++ b/src/app.rs
@@ -357,6 +357,7 @@ where
             //
             // If the object does not exist, then we should return an upload
             // action.
+            let upload_expiry_secs = UPLOAD_EXPIRATION.as_secs() as i32;
             match size {
                 Some(size) => lfs::ResponseObject {
                     oid: object.oid,
@@ -389,7 +390,7 @@ where
                                     )
                                 }),
                             header: None,
-                            expires_in: Some(UPLOAD_EXPIRATION.as_secs() as i32),
+                            expires_in: Some(upload_expiry_secs),
                             expires_at: None,
                         }),
                         verify: Some(lfs::Action {

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,6 +37,8 @@ use crate::lfs;
 use crate::storage::{LFSObject, Namespace, Storage, StorageKey};
 use std::time::Duration;
 
+const UPLOAD_EXPIRATION: Duration = Duration::from_secs(30 * 60);
+
 async fn from_json<T>(mut body: Body) -> Result<T, Error>
 where
     T: for<'de> Deserialize<'de>,
@@ -377,7 +379,7 @@ where
                                         namespace.clone(),
                                         object.oid,
                                     ),
-                                    Duration::new(30 * 60, 0),
+                                    UPLOAD_EXPIRATION,
                                 )
                                 .await
                                 .unwrap_or_else(|| {
@@ -387,7 +389,7 @@ where
                                     )
                                 }),
                             header: None,
-                            expires_in: Some(30 * 60),
+                            expires_in: Some(UPLOAD_EXPIRATION.as_secs() as i32),
                             expires_at: None,
                         }),
                         verify: Some(lfs::Action {

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,6 +35,7 @@ use crate::error::Error;
 use crate::hyperext::RequestExt;
 use crate::lfs;
 use crate::storage::{LFSObject, Namespace, Storage, StorageKey};
+use std::time::Duration;
 
 async fn from_json<T>(mut body: Body) -> Result<T, Error>
 where
@@ -371,10 +372,13 @@ where
                         download: None,
                         upload: Some(lfs::Action {
                             href: storage
-                                .upload_url(&StorageKey::new(
-                                    namespace.clone(),
-                                    object.oid,
-                                ))
+                                .upload_url(
+                                    &StorageKey::new(
+                                        namespace.clone(),
+                                        object.oid,
+                                    ),
+                                    Duration::new(30 * 60, 0),
+                                )
                                 .await
                                 .unwrap_or_else(|| {
                                     format!(
@@ -383,7 +387,7 @@ where
                                     )
                                 }),
                             header: None,
-                            expires_in: None,
+                            expires_in: Some(30 * 60),
                             expires_at: None,
                         }),
                         verify: Some(lfs::Action {

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,13 +71,12 @@ enum Backend {
 
 #[derive(StructOpt)]
 struct GlobalArgs {
-    /// The host or address to listen on. If this is not specified, then `0.0.0.0`
-    /// is used where the port can be specified with `--port` (port 8080 is used by
-    /// default if that is also not specified).
+    /// The host or address to listen on. If this is not specified, then
+    /// `0.0.0.0` is used where the port can be specified with `--port`
+    /// (port 8080 is used by default if that is also not specified).
     #[structopt(long = "host", env = "RUDOLFS_HOST")]
     host: Option<String>,
 
-    
     /// The port to bind to. This is only used if `--host` is not specified.
     #[structopt(long = "port", default_value = "8080", env = "PORT")]
     port: u16,

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,10 @@ struct S3Args {
     /// Amazon S3 path prefix to use.
     #[structopt(long, default_value = "lfs", env = "RUDOLFS_S3_PREFIX")]
     prefix: String,
+
+    /// Logging level to use.
+    #[structopt(long = "cdn", env = "RUDOLFS_S3_CDN")]
+    cdn: Option<String>,
 }
 
 #[derive(StructOpt)]
@@ -168,7 +172,7 @@ impl S3Args {
         addr: SocketAddr,
         global_args: GlobalArgs,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let s3 = S3::new(self.bucket, self.prefix)
+        let s3 = S3::new(self.bucket, self.prefix, self.cdn)
             .map_err(Error::from)
             .await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,10 +71,14 @@ enum Backend {
 
 #[derive(StructOpt)]
 struct GlobalArgs {
-    /// Host or address to listen on.
+    /// The host or address to listen on. If this is not specified, then `0.0.0.0`
+    /// is used where the port can be specified with `--port` (port 8080 is used by
+    /// default if that is also not specified).
     #[structopt(long = "host", env = "RUDOLFS_HOST")]
     host: Option<String>,
 
+    
+    /// The port to bind to. This is only used if `--host` is not specified.
     #[structopt(long = "port", default_value = "8080", env = "PORT")]
     port: u16,
 
@@ -119,7 +123,8 @@ struct S3Args {
     #[structopt(long, default_value = "lfs", env = "RUDOLFS_S3_PREFIX")]
     prefix: String,
 
-    /// Logging level to use.
+    /// The base URL of your CDN. If specified, then all download URLs will be
+    /// prefixed with this URL.
     #[structopt(long = "cdn", env = "RUDOLFS_S3_CDN")]
     cdn: Option<String>,
 }

--- a/src/storage/cached.rs
+++ b/src/storage/cached.rs
@@ -391,4 +391,8 @@ where
     fn public_url(&self, key: &StorageKey) -> Option<String> {
         self.storage.public_url(key)
     }
+
+    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
+        self.storage.upload_url(key).await
+    }
 }

--- a/src/storage/cached.rs
+++ b/src/storage/cached.rs
@@ -20,6 +20,7 @@
 use std::fmt;
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -392,7 +393,11 @@ where
         self.storage.public_url(key)
     }
 
-    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
-        self.storage.upload_url(key).await
+    async fn upload_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.upload_url(key, expires_in).await
     }
 }

--- a/src/storage/cached.rs
+++ b/src/storage/cached.rs
@@ -387,4 +387,8 @@ where
             Some(self.max_size)
         }
     }
+
+    fn public_url(&self, key: &StorageKey) -> Option<String> {
+        self.storage.public_url(key)
+    }
 }

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -248,6 +248,10 @@ impl Storage for Backend {
             }
         }))
     }
+
+    fn public_url(&self, key: &StorageKey) -> Option<String> {
+        None
+    }
 }
 
 /// A simple bytes codec that keeps track of its length.

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -249,7 +249,11 @@ impl Storage for Backend {
         }))
     }
 
-    fn public_url(&self, key: &StorageKey) -> Option<String> {
+    fn public_url(&self, _key: &StorageKey) -> Option<String> {
+        None
+    }
+
+    async fn upload_url(&self, _key: &StorageKey) -> Option<String> {
         None
     }
 }

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -22,6 +22,7 @@ use std::fs::Metadata;
 use std::io;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::time::Duration;
 
 use async_stream::try_stream;
 use async_trait::async_trait;
@@ -253,7 +254,11 @@ impl Storage for Backend {
         None
     }
 
-    async fn upload_url(&self, _key: &StorageKey) -> Option<String> {
+    async fn upload_url(
+        &self,
+        _key: &StorageKey,
+        _expires_in: Duration,
+    ) -> Option<String> {
         None
     }
 }

--- a/src/storage/encrypt.rs
+++ b/src/storage/encrypt.rs
@@ -121,4 +121,8 @@ where
     async fn max_size(&self) -> Option<u64> {
         self.storage.max_size().await
     }
+
+    fn public_url(&self, key: &StorageKey) -> Option<String> {
+        self.storage.public_url(key)
+    }
 }

--- a/src/storage/encrypt.rs
+++ b/src/storage/encrypt.rs
@@ -19,6 +19,7 @@
 // SOFTWARE.
 use chacha::{ChaCha, KeyStream};
 use std::io;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::{Bytes, BytesMut};
@@ -126,7 +127,11 @@ where
         self.storage.public_url(key)
     }
 
-    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
-        self.storage.upload_url(key).await
+    async fn upload_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.upload_url(key, expires_in).await
     }
 }

--- a/src/storage/encrypt.rs
+++ b/src/storage/encrypt.rs
@@ -125,4 +125,8 @@ where
     fn public_url(&self, key: &StorageKey) -> Option<String> {
         self.storage.public_url(key)
     }
+
+    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
+        self.storage.upload_url(key).await
+    }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -227,6 +227,9 @@ pub trait Storage {
 
     /// Returns a publicly accessible URL
     fn public_url(&self, key: &StorageKey) -> Option<String>;
+
+    /// Returns a signed URL
+    async fn upload_url(&self, key: &StorageKey) -> Option<String>;
 }
 
 #[async_trait]
@@ -280,5 +283,9 @@ where
 
     fn public_url(&self, key: &StorageKey) -> Option<String> {
         self.as_ref().public_url(key)
+    }
+
+    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
+        self.as_ref().upload_url(key).await
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -224,6 +224,9 @@ pub trait Storage {
     async fn max_size(&self) -> Option<u64> {
         None
     }
+
+    /// Returns a publicly accessible URL
+    fn public_url(&self, key: &StorageKey) -> Option<String>;
 }
 
 #[async_trait]
@@ -273,5 +276,9 @@ where
     #[inline]
     async fn max_size(&self) -> Option<u64> {
         self.as_ref().max_size().await
+    }
+
+    fn public_url(&self, key: &StorageKey) -> Option<String> {
+        self.as_ref().public_url(key)
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -41,6 +41,7 @@ use std::fmt;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -229,7 +230,11 @@ pub trait Storage {
     fn public_url(&self, key: &StorageKey) -> Option<String>;
 
     /// Returns a signed URL
-    async fn upload_url(&self, key: &StorageKey) -> Option<String>;
+    async fn upload_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String>;
 }
 
 #[async_trait]
@@ -285,7 +290,11 @@ where
         self.as_ref().public_url(key)
     }
 
-    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
-        self.as_ref().upload_url(key).await
+    async fn upload_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.as_ref().upload_url(key, expires_in).await
     }
 }

--- a/src/storage/retrying.rs
+++ b/src/storage/retrying.rs
@@ -87,4 +87,8 @@ where
     async fn max_size(&self) -> Option<u64> {
         self.storage.max_size().await
     }
+
+    fn public_url(&self, key: &StorageKey) -> Option<String> {
+        self.storage.public_url(key)
+    }
 }

--- a/src/storage/retrying.rs
+++ b/src/storage/retrying.rs
@@ -18,6 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use backoff::{future::FutureOperation, ExponentialBackoff};
@@ -92,7 +93,11 @@ where
         self.storage.public_url(key)
     }
 
-    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
-        self.storage.upload_url(key).await
+    async fn upload_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.upload_url(key, expires_in).await
     }
 }

--- a/src/storage/retrying.rs
+++ b/src/storage/retrying.rs
@@ -91,4 +91,8 @@ where
     fn public_url(&self, key: &StorageKey) -> Option<String> {
         self.storage.public_url(key)
     }
+
+    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
+        self.storage.upload_url(key).await
+    }
 }

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -36,7 +36,7 @@ use rusoto_sts::WebIdentityProvider;
 
 use super::{LFSObject, Storage, StorageKey, StorageStream};
 use rusoto_s3::util::{PreSignedRequest, PreSignedRequestOption};
-use tokio::time::Duration;
+use std::time::Duration;
 
 #[derive(Debug, From, Display)]
 pub enum Error {

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -322,7 +322,11 @@ where
         }
     }
 
-    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
+    async fn upload_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
         let request = PutObjectRequest {
             bucket: self.bucket.clone(),
             key: self.key_to_path(&key),
@@ -335,9 +339,7 @@ where
         let presigned_url = request.get_presigned_url(
             &self.region,
             &credentials,
-            &PreSignedRequestOption {
-                expires_in: Duration::new(1800, 0),
-            },
+            &PreSignedRequestOption { expires_in },
         );
         Some(presigned_url)
     }

--- a/src/storage/verify.rs
+++ b/src/storage/verify.rs
@@ -164,4 +164,8 @@ where
     fn public_url(&self, key: &StorageKey) -> Option<String> {
         self.storage.public_url(key)
     }
+
+    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
+        self.storage.upload_url(key).await
+    }
 }

--- a/src/storage/verify.rs
+++ b/src/storage/verify.rs
@@ -19,6 +19,7 @@
 // SOFTWARE.
 use std::io;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use derive_more::{Display, From};
@@ -165,7 +166,11 @@ where
         self.storage.public_url(key)
     }
 
-    async fn upload_url(&self, key: &StorageKey) -> Option<String> {
-        self.storage.upload_url(key).await
+    async fn upload_url(
+        &self,
+        key: &StorageKey,
+        expires_in: Duration,
+    ) -> Option<String> {
+        self.storage.upload_url(key, expires_in).await
     }
 }

--- a/src/storage/verify.rs
+++ b/src/storage/verify.rs
@@ -160,4 +160,8 @@ where
     async fn max_size(&self) -> Option<u64> {
         self.storage.max_size().await
     }
+
+    fn public_url(&self, key: &StorageKey) -> Option<String> {
+        self.storage.public_url(key)
+    }
 }


### PR DESCRIPTION
This PR added three features:
- Added a PORT environment variable that allows the user to specify the port only. This is added to make deployment on certain PaaS (such as Heroku) easier.
- Added a RUDOLFS_S3_CDN environment variable that allows the user to specify a CDN URL. Right now, all of the files were essentially proxied through Rudolfs. It would me more efficient for the user to retrieve the files directly from the s3 bucket if they set the bucket to public. This would also make local caching unnecessary, as all files would be cached efficiently on the CDN.
- Modified the Upload logic so that we retrieve a presigned URL to be included in the action object. This way, the upload traffic will also go directly to the s3 bucket.


Future work:
Use signed URL to make RUDOLFS_S3_CDN work for private buckets also