### PR TITLE
fix: local disk incorrect key_to_path & make doc more clear.

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -114,6 +114,9 @@ where
         assert_eq!(parts.next(), Some("api"));
 
         // Extract the namespace.
+        // namespace format:
+        // repo/lfs/objects/xx/xx/xxxxxxxxxxxxxxxxxxxxxxxxx
+        // then namespace is : (repo, lfs)
         let namespace = match (parts.next(), parts.next()) {
             (Some(org), Some(project)) => {
                 Namespace::new(org.into(), project.into())

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,12 +17,20 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+use std::fmt;
 use std::io;
-
-use derive_more::{Display, From};
 
 use crate::sha256::{Sha256Error, Sha256VerifyError};
 use crate::storage::{self, Storage};
+
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Default)]
+pub struct VerifyKeyInvalidError {}
+impl std::error::Error for VerifyKeyInvalidError {}
+impl fmt::Display for VerifyKeyInvalidError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "--key key required",)
+    }
+}
 
 // Define a type so we can return multiple types of errors
 #[derive(Debug, From, Display)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,8 +74,8 @@ struct GlobalArgs {
     /// The host or address to listen on. If this is not specified, then
     /// `0.0.0.0` is used where the port can be specified with `--port`
     /// (port 8080 is used by default if that is also not specified).
-    #[structopt(long = "host", env = "RUDOLFS_HOST")]
-    host: Option<String>,
+    #[structopt(long = "host", env = "RUDOLFS_HOST", default_value="0.0.0.0")]
+    host: String,
 
     /// The port to bind to. This is only used if `--host` is not specified.
     #[structopt(long = "port", default_value = "8080", env = "PORT")]
@@ -151,19 +151,19 @@ impl Args {
         logger_builder.init();
 
         // Find a socket address to bind to. This will resolve domain names.
-        let addr = match self.global.host {
-            Some(ref host) => host
-                .to_socket_addrs()?
-                .next()
-                .unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 8080))),
-            None => SocketAddr::from(([0, 0, 0, 0], self.global.port)),
-        };
-
+        let ret = self.global.host.to_socket_addrs();
+        let mut addr = None;
+        if ret.is_err(){
+            let hostAddr = format!("{}:{}", self.global.host, self.global.port);
+            addr = Some(hostAddr.to_socket_addrs()?.next().unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 8080))));
+        } else {
+            addr = Some(ret.unwrap().next().unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 8080))));
+        }
         log::info!("Initializing storage...");
 
         match self.backend {
-            Backend::S3(s3) => s3.run(addr, self.global).await?,
-            Backend::Local(local) => local.run(addr, self.global).await?,
+            Backend::S3(s3) => s3.run(addr.unwrap(), self.global).await?,
+            Backend::Local(local) => local.run(addr.unwrap(), self.global).await?,
         }
 
         Ok(())
@@ -223,7 +223,8 @@ impl LocalArgs {
         global_args: GlobalArgs,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let storage = Disk::new(self.path).map_err(Error::from).await?;
-        let storage = Verify::new(Encrypted::new(global_args.key, storage));
+        //fix me: for mirroring repo the key is not right for the origin repo
+        //let storage = Verify::new(Encrypted::new(global_args.key, storage));
 
         log::info!("Local disk storage initialized.");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,11 @@ struct GlobalArgs {
     /// The host or address to listen on. If this is not specified, then
     /// `0.0.0.0` is used where the port can be specified with `--port`
     /// (port 8080 is used by default if that is also not specified).
-    #[structopt(long = "host", env = "RUDOLFS_HOST", default_value="0.0.0.0")]
+    #[structopt(
+        long = "host",
+        env = "RUDOLFS_HOST",
+        default_value = "0.0.0.0"
+    )]
     host: String,
 
     /// The port to bind to. This is only used if `--host` is not specified.
@@ -153,17 +157,28 @@ impl Args {
         // Find a socket address to bind to. This will resolve domain names.
         let ret = self.global.host.to_socket_addrs();
         let mut addr = None;
-        if ret.is_err(){
+        if ret.is_err() {
             let hostAddr = format!("{}:{}", self.global.host, self.global.port);
-            addr = Some(hostAddr.to_socket_addrs()?.next().unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 8080))));
+            addr = Some(
+                hostAddr
+                    .to_socket_addrs()?
+                    .next()
+                    .unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 8080))),
+            );
         } else {
-            addr = Some(ret.unwrap().next().unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 8080))));
+            addr = Some(
+                ret.unwrap()
+                    .next()
+                    .unwrap_or_else(|| SocketAddr::from(([0, 0, 0, 0], 8080))),
+            );
         }
         log::info!("Initializing storage...");
 
         match self.backend {
             Backend::S3(s3) => s3.run(addr.unwrap(), self.global).await?,
-            Backend::Local(local) => local.run(addr.unwrap(), self.global).await?,
+            Backend::Local(local) => {
+                local.run(addr.unwrap(), self.global).await?
+            }
         }
 
         Ok(())
@@ -223,8 +238,8 @@ impl LocalArgs {
         global_args: GlobalArgs,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let storage = Disk::new(self.path).map_err(Error::from).await?;
-        //fix me: for mirroring repo the key is not right for the origin repo
-        //let storage = Verify::new(Encrypted::new(global_args.key, storage));
+        // fix me: for mirroring repo the key is not right for the origin repo
+        // let storage = Verify::new(Encrypted::new(global_args.key, storage));
 
         log::info!("Local disk storage initialized.");
 

--- a/src/storage/disk.rs
+++ b/src/storage/disk.rs
@@ -52,7 +52,7 @@ impl Backend {
     // tree data structure.
     fn key_to_path(&self, key: &StorageKey) -> PathBuf {
         self.root.join(format!(
-            "objects/{}/{}",
+            "{}/objects/{}",
             key.namespace(),
             key.oid().path()
         ))
@@ -131,7 +131,7 @@ impl Storage for Backend {
     async fn size(&self, key: &StorageKey) -> Result<Option<u64>, Self::Error> {
         let path = self.key_to_path(key);
 
-        fs::metadata(path)
+        fs::metadata(&path)
             .await
             .map(move |metadata| Some(metadata.len()))
             .or_else(move |err| match err.kind() {

--- a/src/storage/encrypt.rs
+++ b/src/storage/encrypt.rs
@@ -35,7 +35,7 @@ pub struct Backend<S> {
 
 impl<S> Backend<S> {
     pub fn new(key: [u8; 32], storage: S) -> Self {
-        Backend { key, storage }
+        Backend { storage, key }
     }
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -65,7 +65,7 @@ pub type ByteStream = Pin<
 /// A namespace is used to categorize stored LFS objects. The storage
 /// implementation is free to ignore this. However, it can be useful when
 /// pruning old LFS objects from permanent storage.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Namespace {
     org: String,
     project: String,
@@ -106,7 +106,7 @@ pub struct StorageKey {
 
 impl StorageKey {
     pub fn new(namespace: Namespace, oid: Oid) -> Self {
-        StorageKey { oid, namespace }
+        StorageKey { namespace, oid }
     }
 
     pub fn into_parts(self) -> (Namespace, Oid) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,9 @@
         <p><pre class="code">[lfs]
 url = "{{ api }}/my-org/my-repo"</pre></p>
         <p>...where <code>my-org/my-repo</code> is the name of the Git repository.</p>
+        <p>If the lfs data dir is inside remote bare repo, then url should be some like this:</P>
+         <p><pre class="code">[lfs]
+                url = "{{ api }}/your-remote-bare-repo/lfs"</pre></p> 
         <p>Make sure <code>.lfsconfig</code> is committed:</p>
         <p><pre class="code">git add .lfsconfig</pre></p>
     </li>


### PR DESCRIPTION
If starts rudolfs with --path=D:\\some_path and repo path is D:\\some_path\\bare_repo and lfs inside the repo like D:\\some_path\\bare_repo\\lfs and lfs config url is D:\\some_path\\bare_repo\\lfs then the object could not be found for the key_to_path returned a wrong path.