### PR TITLE
Use docker supplied tini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+# v0.4.0
+
+- Rely on docker / docker-compose to package `tini` (or compatible init system).
+  All modern versions of the docker daemon support `--init`. Note that if you
+  were using any previous version of rudolfs you now need to ensure
+  that `--init` is added to your `docker run` arguments. If you are launching
+  rudolfs via the `docker-compose` configs supplied with rudolfs then `--init`
+  is enabled by default.
+
 ## v0.3.6
 
 - Bump versions of various dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1130,7 +1130,7 @@ dependencies = [
 
 [[package]]
 name = "rudolfs"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "askama",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rudolfs"
-version = "0.3.6"
+version = "0.4.0"
 authors = ["Jason White <rust@jasonwhite.io>"]
 edition = "2021"
 description = """

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,17 +10,6 @@ RUN \
 
 ENV PKG_CONFIG_ALLOW_CROSS=1
 
-# Use Tini as our PID 1. This will enable signals to be handled more correctly.
-#
-# Note that this can't be downloaded inside the scratch container as we have no
-# chmod command.
-#
-# TODO: Use `--init` instead when it is more well-supported (this should be the
-# case by Jan 1, 2020).
-ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
-RUN chmod +x /tini
-
 # Build the real project.
 COPY ./ ./
 
@@ -38,11 +27,9 @@ FROM scratch
 EXPOSE 8080
 VOLUME ["/data"]
 
-COPY --from=build /tini /tini
-
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 COPY --from=build /build/ /
 
-ENTRYPOINT ["/tini", "--", "/rudolfs"]
+ENTRYPOINT ["/rudolfs"]
 CMD ["--cache-dir", "/data"]

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -22,6 +22,7 @@ services:
     volumes:
       - data:/data
     restart: always
+    init: true
     environment:
       - AWS_REGION
       - AWS_ACCESS_KEY_ID
@@ -32,8 +33,6 @@ services:
       - LFS_MAX_CACHE_SIZE
       - AWS_S3_ENDPOINT=http://minio:9000
     entrypoint:
-      - /tini
-      - --
       - /rudolfs
       - --cache-dir
       - /data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - data:/data
     restart: always
+    init: true
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
@@ -19,8 +20,6 @@ services:
       - LFS_S3_BUCKET
       - LFS_MAX_CACHE_SIZE
     entrypoint:
-      - /tini
-      - --
       - /rudolfs
       - --cache-dir
       - /data


### PR DESCRIPTION
Marking this as draft for now as most of the commits in the series should not be merged as part of this PR.

See #51 for details.

Only the last commit in the current (as of time of writing) series is properly part of this PR.

It is just pointless to introduce another merge conflict in the `CHANGELOG.md` given that I expect #46 is about to be merged.  Will just rebase after that happens and skip the potential confusion of moving around in version numbers.