### PR TITLE
Add optional encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
+## v0.3.7
+
+ - Made encryption optional. If `--key` is not specified, LFS objects are not
+   encrypted.
+
 ## v0.3.6
 
-- Bumped versions of various dependencies.
-- Fixed Minio environment variables in `docker-compose.minio.yml`
-  * `MINIO_ACCESS_KEY` was renamed to `MINIO_ROOT_USER`
-  * `MINIO_SECRET_KEY` was renamed to `MINIO_ROOT_PASSWORD`
+ - Bumped versions of various dependencies.
+ - Fixed Minio environment variables in `docker-compose.minio.yml`
+   * `MINIO_ACCESS_KEY` was renamed to `MINIO_ROOT_USER`
+   * `MINIO_SECRET_KEY` was renamed to `MINIO_ROOT_PASSWORD`
 
 ## v0.3.5
 

--- a/README.md
+++ b/README.md
@@ -43,22 +43,25 @@ know by submitting an issue.
 
 ## Running It
 
-### Generate an encryption key
+### Generate an encryption key (optional)
 
-All LFS objects are encrypted with the xchacha20 symmetric stream cipher. You
-must generate a 32-byte encryption key before starting the server.
+If configured, all LFS objects are encrypted with the xchacha20 symmetric stream
+cipher. You must generate a 32-byte encryption key before starting the server.
 
 Generating a random key is easy:
 
     openssl rand -hex 32
 
 Keep this secret and save it in a password manager so you don't lose it. We will
-pass this to the server below.
+pass this to the server below via the `--key` option. If the `--key` option is
+**not** specified, then the LFS objects are **not** encrypted.
 
 **Note**:
- - If the key ever changes, all existing LFS objects will become garbage.
-   When the Git LFS client attempts to download them, the SHA256 verification
-   step will fail.
+ - If the key ever changes (or if encryption is disabled), all existing LFS
+   objects will become garbage. When the Git LFS client attempts to download
+   them, the SHA256 verification step will fail.
+ - Likewise, if encryption is later enabled after it has been disabled, all
+   existing unencrypted LFS objects will be seen as garbage.
  - LFS objects in both the cache and in permanent storage are encrypted.
    However, objects are decrypted before being sent to the LFS client, so take
    any necessary precautions to keep your intellectual property safe.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,4 @@
 max_width = 80
 format_strings = true
-error_on_line_overflow = true
-error_on_unformatted = true
 normalize_comments = true
 wrap_comments = true
-license_template_path = ".license_template"

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,7 @@ struct GlobalArgs {
         parse(try_from_str = FromHex::from_hex),
         env = "RUDOLFS_KEY"
     )]
-    key: [u8; 32],
+    key: Option<[u8; 32]>,
 
     /// Root directory of the object cache. If not specified or if the local
     /// disk is the storage backend, then no local disk cache will be used.
@@ -156,8 +156,12 @@ impl S3Args {
         addr: SocketAddr,
         global_args: GlobalArgs,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut builder = S3ServerBuilder::new(self.bucket, global_args.key);
+        let mut builder = S3ServerBuilder::new(self.bucket);
         builder.prefix(self.prefix);
+
+        if let Some(key) = global_args.key {
+            builder.key(key);
+        }
 
         if let Some(cdn) = self.cdn {
             builder.cdn(cdn);
@@ -181,7 +185,11 @@ impl LocalArgs {
         addr: SocketAddr,
         global_args: GlobalArgs,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut builder = LocalServerBuilder::new(self.path, global_args.key);
+        let mut builder = LocalServerBuilder::new(self.path);
+
+        if let Some(key) = global_args.key {
+            builder.key(key);
+        }
 
         if let Some(cache_dir) = global_args.cache_dir {
             let max_cache_size = global_args

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,6 +17,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+#![allow(unused)]
 use std::fs::{self, File};
 use std::io;
 use std::net::SocketAddr;


### PR DESCRIPTION
Makes the `--key` argument optional. If not specified, encryption is disabled.

This is useful for allowing the underlying file system to do compression. This may also be desirable if you trust the encryption methods of the storage medium (i.e., S3 or your local disk). Disabling encryption will probably also improve server performance.