### PR TITLE
index: send html content-type

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -95,6 +95,7 @@ where
 
         Ok(Response::builder()
             .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "text/html")
             .body(template.render()?.into())?)
     }
 


### PR DESCRIPTION
I've observed just text in the browser, while that can be fixed in the reverse proxy, we might as well send the right content type since we know the `index.html` is `text/html`.