### PR TITLE
fix(s3): treat empty --prefix as "no prefix
  component"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -101,7 +101,8 @@ struct S3Args {
     #[structopt(long, env = "RUDOLFS_S3_BUCKET")]
     bucket: String,
 
-    /// Amazon S3 path prefix to use.
+    /// Amazon S3 path prefix to use: `<prefix>/<namespace>/<oid>`
+    /// Passing an empty string omits the prefix: `<namespace>/<oid>`.
     #[structopt(long, default_value = "lfs", env = "RUDOLFS_S3_PREFIX")]
     prefix: String,
 

--- a/src/storage/s3.rs
+++ b/src/storage/s3.rs
@@ -261,7 +261,11 @@ impl<C> Backend<C> {
     }
 
     fn key_to_path(&self, key: &StorageKey) -> String {
-        format!("{}/{}/{}", self.prefix, key.namespace(), key.oid().path())
+        if self.prefix.is_empty() {
+            format!("{}/{}", key.namespace(), key.oid().path())
+        } else {
+            format!("{}/{}/{}", self.prefix, key.namespace(), key.oid().path())
+        }
     }
 }
 


### PR DESCRIPTION
Previously, `--prefix=""` (or `RUDOLFS_S3_PREFIX=""`) produced S3 keys with a leading slash, e.g. `/<namespace>/<oid>`, manifesting as "/" in S3 listings.

This PR makes empty prefix mean "skip the prefix component entirely", so keys become `<namespace>/<oid>`. 

Default behavior (`--prefix=lfs`) is unchanged, only the literal empty-string case is affected.
