### PR TITLE
fix(docker): build multi-arch images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,12 @@ jobs:
         name: Checkout sources
         uses: actions/checkout@v2
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+      -
         name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -130,6 +136,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM rust:1.91.1 as build
 
-ENV CARGO_BUILD_TARGET=x86_64-unknown-linux-musl
+ARG TARGETARCH
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN \
 	apt-get update && \
-	apt-get -y install ca-certificates musl-tools && \
-	rustup target add ${CARGO_BUILD_TARGET}
+	apt-get -y install ca-certificates musl-tools
 
 ENV PKG_CONFIG_ALLOW_CROSS=1
 
@@ -18,15 +17,20 @@ ENV PKG_CONFIG_ALLOW_CROSS=1
 # TODO: Use `--init` instead when it is more well-supported (this should be the
 # case by Jan 1, 2020).
 ENV TINI_VERSION v0.18.0
-ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static /tini
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${TARGETARCH} /tini
 RUN chmod +x /tini
 
 # Build the real project.
 COPY ./ ./
 
-RUN cargo build --release
-
 RUN \
+	case "${TARGETARCH}" in \
+		amd64) CARGO_BUILD_TARGET="x86_64-unknown-linux-musl" ;; \
+		arm64) CARGO_BUILD_TARGET="aarch64-unknown-linux-musl" ;; \
+		*) echo "unsupported architecture: ${TARGETARCH}" >&2; exit 1 ;; \
+	esac && \
+	rustup target add "${CARGO_BUILD_TARGET}" && \
+	cargo build --release --target "${CARGO_BUILD_TARGET}" && \
 	mkdir -p /build && \
 	cp target/${CARGO_BUILD_TARGET}/release/rudolfs /build/ && \
 	strip /build/rudolfs


### PR DESCRIPTION
The current Dockerfile hardcodes `CARGO_BUILD_TARGET=x86_64-unknown-linux-musl` and downloads a single-arch `tini` binary, so the Docker image only works on amd64.

This PR makes the build multi-arch aware (amd64 + arm64) by selecting the appropriate Rust target and `tini` binary based on `TARGETARCH`.

- Closes #86